### PR TITLE
chroe(package): Added a `browser` field to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Design-system utils for working with JS-in-CSS",
   "main": "./cjs/index.js",
   "module": "./src/index.js",
+  "browser": "./cjs/index.js",
   "types": "./src/index.d.ts",
   "repository": "https://github.com/mrmartineau/design-system-utils",
   "directories": {


### PR DESCRIPTION
The reason of this is to allow webpack resolve the module to
`./cjs/index.js` when the target `web` is set.

More info: https://webpack.js.org/configuration/resolve/#resolve-mainfields